### PR TITLE
Handle pending BLE connections on disconnect all

### DIFF
--- a/FastBleLib/src/main/java/com/clj/fastble/bluetooth/MultipleBluetoothController.java
+++ b/FastBleLib/src/main/java/com/clj/fastble/bluetooth/MultipleBluetoothController.java
@@ -87,7 +87,11 @@ public class MultipleBluetoothController {
         for (Map.Entry<String, BleBluetooth> stringBleBluetoothEntry : bleLruHashMap.entrySet()) {
             stringBleBluetoothEntry.getValue().disconnect();
         }
+        for (Map.Entry<String, BleBluetooth> stringBleBluetoothEntry : bleTempHashMap.entrySet()) {
+            stringBleBluetoothEntry.getValue().disconnect();
+        }
         bleLruHashMap.clear();
+        bleTempHashMap.clear();
     }
 
     public synchronized void destroy() {

--- a/README.md
+++ b/README.md
@@ -499,7 +499,9 @@ If you want to quickly preview all the functions, you can download APK as a test
 
 - #### Disconnect all devices
 
-	`void disconnectAllDevice()`
+        `void disconnectAllDevice()`
+
+        Disconnects all active connections and cancels any pending connections.
 
         BleManager.getInstance().disconnectAllDevice();
 


### PR DESCRIPTION
## Summary
- cancel temporary connections in `disconnectAllDevice`
- note new behaviour in README

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_684fa7081308832eaebc8b9f8e02b29c