### PR TITLE
Handle cancel disconnect without reconnect

### DIFF
--- a/app/src/main/java/com/clj/blesample/MainActivity.java
+++ b/app/src/main/java/com/clj/blesample/MainActivity.java
@@ -257,6 +257,14 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     }
 
     private void connect(final BleDevice bleDevice) {
+        progressDialog.setCancelable(true);
+        progressDialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface dialog) {
+                BleManager.getInstance().disconnect(bleDevice);
+            }
+        });
+
         BleManager.getInstance().connect(bleDevice, new BleGattCallback() {
             @Override
             public void onStartConnect() {


### PR DESCRIPTION
## Summary
- clear pending reconnect messages when disconnecting
- treat cancelled connection as active disconnect
- allow cancelling connection from sample progress dialog

## Testing
- `bash gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa705c1dc832ebe378ded43163cf6